### PR TITLE
fix: update service rate retrieval to handle unknown service names

### DIFF
--- a/server/src/Models/ServiceQuote.php
+++ b/server/src/Models/ServiceQuote.php
@@ -123,7 +123,7 @@ class ServiceQuote extends Model
 
     public function getServiceRateNameAttribute(): string
     {
-        return data_get($this, 'serviceRate.service_name');
+        return data_get($this, 'serviceRate.service_name') ?? 'unknown_or_deleted';
     }
 
     public function fromIntegratedVendor(): bool


### PR DESCRIPTION
- Modify getServiceRateNameAttribute to return 'unknown_or_deleted' if service name is not found.